### PR TITLE
Fixed memory leaks

### DIFF
--- a/Source/JiNode.swift
+++ b/Source/JiNode.swift
@@ -299,6 +299,7 @@ public class JiNode {
 		let nodeSet = xPathObject.memory.nodesetval
 		if nodeSet == nil || nodeSet.memory.nodeNr == 0 || nodeSet.memory.nodeTab == nil {
 			// NodeSet is nil.
+            xmlXPathFreeObject(xPathObject)
 			return []
 		}
 		

--- a/Source/JiNode.swift
+++ b/Source/JiNode.swift
@@ -60,7 +60,7 @@ public class JiNode {
 	/// The xmlNodePtr for this node.
 	public let xmlNode: xmlNodePtr
 	/// The Ji document contians this node.
-	public let document: Ji
+	public unowned let document: Ji
 	/// Node type.
 	public let type: JiNodeType
 	


### PR DESCRIPTION
There were small memory leaks that caused me some problems, so I fixed them. 
First one is retain cycle between `Ji` and `JiNode` classes. I fixed this with making `document` object `unowned`. 
Other one is a little bit trivial, while doing a xPath query if there's no nodes in  `xPathObject`, it was returning an empty array without freeing `xPathObject`. This one is fixed by adding `xmlXPathFreeObject` before the return call. 
