### PR TITLE
Add CoreFoundation import

### DIFF
--- a/Sources/Ji/Ji.swift
+++ b/Sources/Ji/Ji.swift
@@ -24,6 +24,7 @@
 //  SOFTWARE.
 
 import Foundation
+import CoreFoundation
 import Clibxml2
 
 public typealias 戟 = Ji


### PR DESCRIPTION
Hi! Compiling Ji on Linux failed with multiple errors

```
error: use of unresolved identifier 'CFStringConvertNSStringEncodingToEncoding'
    let cfEncoding = CFStringConvertNSStringEncodingToEncoding(encoding.rawValue)
error: use of undeclared type 'CFString'
    let cfEncodingAsString: CFString = CFStringConvertEncodingToIANACharSetName(cfEncoding)
```

and so on.

Adding explicit `import CoreFoundation` solved this issue.